### PR TITLE
Fix WASAPI haptic playback truncating clips when endpoint sample rate differs from source

### DIFF
--- a/Samples/System/Haptics/HapticsManager/Audio/WaveSampleGenerator.cpp
+++ b/Samples/System/Haptics/HapticsManager/Audio/WaveSampleGenerator.cpp
@@ -292,6 +292,21 @@ namespace ATG
 
         WaveSampleReader reader(pWaveData, waveSize, pSourceWfx);
 
+        // Resample the source to the destination sample rate using nearest-neighbor
+        // selection. A phase accumulator tracks how many source frames have been consumed
+        // versus destination frames written: each destination frame maps back to source
+        // frame (dstFrame / sampleRatio), and the source is advanced until it reaches that
+        // position. This works for any ratio, including fractional ratios and downsampling.
+        constexpr uint32_t nMaxChannels = 8;
+        float currentBlock[nMaxChannels] = {};
+        double srcFramesConsumed = 0.0;   // number of source frames read so far
+        double dstFramesWritten = 0.0;    // number of destination frames written so far
+        bool readerEOF = false;
+
+        // Prime the first source frame.
+        reader.ReadBlock(currentBlock, nMaxChannels);
+        srcFramesConsumed = 1.0;
+
         for (uint32_t i = 0; i < renderBufferCount; i++)
         {
             RenderBuffer* sampleBuffer = new RenderBuffer();
@@ -304,18 +319,23 @@ namespace ATG
 
             while (!writer.IsEOF())
             {
-                constexpr uint32_t nMaxChannels = 8;
-                float channelData[nMaxChannels];
-
-                //  Get a block of channel data (as much as we're interested in).
-                //  If the reader is at end of file then this returns a block
-                //  of zeroed samples.
-                reader.ReadBlock(channelData, nMaxChannels);
-
-                for (unsigned int j = 0; j < sampleRatio; j++)
+                //  Advance the source until it corresponds to the destination frame we are
+                //  about to write (source frame = dstFrame / sampleRatio).
+                double neededSrcFrames = (dstFramesWritten + 1.0) / (double)sampleRatio;
+                while (srcFramesConsumed < neededSrcFrames && !readerEOF)
                 {
-                    writer.WriteBlock(channelData, nMaxChannels);
+                    if (reader.IsEOF())
+                    {
+                        readerEOF = true;
+                        ZeroMemory(currentBlock, sizeof(currentBlock));
+                        break;
+                    }
+                    reader.ReadBlock(currentBlock, nMaxChannels);
+                    srcFramesConsumed += 1.0;
                 }
+
+                writer.WriteBlock(currentBlock, nMaxChannels);
+                dstFramesWritten += 1.0;
             }
 
             *m_SampleQueueTail = sampleBuffer;
@@ -348,6 +368,11 @@ namespace ATG
         CopyMemory(pData, sampleBuffer->Buffer, bytesToRead);
 
         m_SampleQueue = m_SampleQueue->Next;
+        if (m_SampleQueue == nullptr)
+        {
+            m_SampleQueueTail = &m_SampleQueue;
+        }
+        delete sampleBuffer;   // free the consumed buffer (~RenderBuffer frees Buffer)
 
         return S_OK;
     }
@@ -364,6 +389,8 @@ namespace ATG
         {
             RenderBuffer* sampleBuffer = m_SampleQueue;
             m_SampleQueue = sampleBuffer->Next;
+            delete sampleBuffer;   // ~RenderBuffer frees Buffer
         }
+        m_SampleQueueTail = &m_SampleQueue;
     }
 }


### PR DESCRIPTION
## Summary

Fixes Advanced Haptics WASAPI playback for WAV files when the haptic audio endpoint sample rate is not an integer multiple of the source WAV sample rate. The previous resampling loop could under/overproduce destination frames and silently drop the tail of longer clips. This change also fixes RenderBuffer leaks in the sample queue cleanup paths.

## Repro steps

1. Build the Advanced Haptics sample.
2. Connect a controller whose haptic audio endpoint sample rate differs from 48 kHz.
3. Select a multi-second WAV clip, such as an 8-beat 48 kHz clip.
4. Press **Play WASAPI (L1)**.
   - Before this fix: only the beginning plays/vibrates, for example only the first beat.
5. Press **Play XAudio2 (R1)**.
   - XAudio2 playback works because XAudio2 performs resampling natively.

## Root cause

`WaveSampleGenerator::GenerateSampleBuffer` computed `sampleRatio` as a `float`, but used it as the upper bound of an integer loop:

```cpp
for (unsigned int j = 0; j < sampleRatio; j++)
{
    writer.WriteBlock(channelData, nMaxChannels);
}
```

For non-integer ratios, this writes a whole-integer number of destination blocks per source block. As a result, the pre-sized render buffers can be exhausted before all source frames are consumed, silently truncating the tail of longer clips.

## Fix

- Replaced the integer-loop resampler with a phase-accumulator nearest-neighbor resampler.
  - The source position advances by exactly `1 / sampleRatio` source frames per destination frame.
  - Fractional ratios and downsampling are handled correctly.
- Fixed RenderBuffer ownership cleanup:
  - `FillSampleBuffer` now deletes each consumed `RenderBuffer`.
  - `Flush` now deletes all remaining queued `RenderBuffer` objects and restores the queue tail pointer.

## Testing

- Built Debug|x64 with Visual Studio.
- Verified an 8-beat 48 kHz clip now plays fully through both **Play WASAPI (L1)** and **Play XAudio2 (R1)**.

## Notes

- Nearest-neighbor resampling is consistent with the intent and complexity level of this sample.
- No public API changes.
- Single-file change in `Samples/System/Haptics/HapticsManager/Audio/WaveSampleGenerator.cpp`.
