### PR TITLE
Prevent restarting haptic playback from gamepad/keyboard while a clip plays

### DIFF
--- a/Samples/System/Haptics/haptics.cpp
+++ b/Samples/System/Haptics/haptics.cpp
@@ -202,16 +202,31 @@ void Sample_Draw(float uiScale)
 
                 ImGui::Dummy(ImVec2(0, 20));
 
-                ImGui::BeginDisabled(hapticsDevice->IsPlaying());
-                    if(ImGui::Button("Play WASAPI (L1)", ImVec2(160*uiScale, 50*uiScale)) || IsButtonPressed(state.buttons, context.lastGamepadState.buttons, GameInputGamepadButtons::GameInputGamepadLeftShoulder))
+                const bool isPlaying = hapticsDevice->IsPlaying();
+
+                ImGui::BeginDisabled(isPlaying);
+                    // Always draw the buttons (ImGui requires the call every frame), but gate the
+                    // resulting action on !isPlaying. ImGui::BeginDisabled only blocks new mouse/Tab
+                    // focus; it does NOT block keyboard Space/Enter on an item that already had focus,
+                    // and it does not affect the "|| IsButtonPressed(...)" gamepad shortcut at all.
+                    // Gating the action closes both gaps so a clip cannot be restarted (or the other
+                    // engine started) mid-play, and SetWindowFocus(nullptr) drops focus so the
+                    // disabled button does not keep showing a pressed animation when Space is held.
+                    const bool wasapiPressed = ImGui::Button("Play WASAPI (L1)", ImVec2(160*uiScale, 50*uiScale))
+                        || IsButtonPressed(state.buttons, context.lastGamepadState.buttons, GameInputGamepadButtons::GameInputGamepadLeftShoulder);
+                    if(!isPlaying && wasapiPressed)
                     {
                         hapticsDevice->PlayWAVFile(context.mediaItem.filename.c_str(), HapticPlaybackEngine::WASAPI);
+                        ImGui::SetWindowFocus(nullptr);
                     }
                     ImGui::SameLine();
 
-                    if(ImGui::Button("Play XAudio2 (R1)", ImVec2(160*uiScale, 50*uiScale)) || IsButtonPressed(state.buttons, context.lastGamepadState.buttons, GameInputGamepadButtons::GameInputGamepadRightShoulder))
+                    const bool xaudioPressed = ImGui::Button("Play XAudio2 (R1)", ImVec2(160*uiScale, 50*uiScale))
+                        || IsButtonPressed(state.buttons, context.lastGamepadState.buttons, GameInputGamepadButtons::GameInputGamepadRightShoulder);
+                    if(!isPlaying && xaudioPressed)
                     {
                         hapticsDevice->PlayWAVFile(context.mediaItem.filename.c_str(), HapticPlaybackEngine::XAudio2);
+                        ImGui::SetWindowFocus(nullptr);
                     }
                 ImGui::EndDisabled();
 


### PR DESCRIPTION
## Summary

While a clip is playing, the **Play WASAPI (L1)** and **Play XAudio2 (R1)** buttons could still be retriggered via the controller or the keyboard, restarting playback from the beginning or starting the other engine. Only mouse clicks were correctly blocked. This change gates both play actions on `!IsPlaying()` for every input path.

## Repro steps

1. Build and run the Advanced Haptics sample.
2. Connect a controller and select a multi-second clip.
3. Start playback, then while it is still playing:
   - Press the controller **L1/R1** again → playback restarts from the beginning (bug).
   - With **R1** activated by keyboard Space, the button keeps focus; pressing Space again retriggers it (bug).
   - Start **L1** while **R1** is playing (or vice versa) → both play (bug).
   - Mouse clicks on the buttons are correctly ignored (expected).

## Root cause

The play buttons were wrapped in `ImGui::BeginDisabled(IsPlaying())`, but `BeginDisabled` only suppresses mouse interaction. The gamepad shortcut (`|| IsButtonPressed(...)`) bypassed the disabled state entirely, and ImGui still activates keyboard Space/Enter on a button that already had focus, so playback could be retriggered through those paths.

## Fix

- Always draw the buttons (ImGui requires the call every frame) but gate each play action on `!isPlaying` so mouse, keyboard (Space/Enter) and gamepad (L1/R1) paths are all blocked while a clip is playing, and the two engines are mutually exclusive.
- Call `ImGui::SetWindowFocus(nullptr)` when playback starts so the now-disabled button does not keep showing a pressed animation when Space is held.

## Testing

- Built Debug|x64 with Visual Studio.
- Verified L1/R1 cannot retrigger playback mid-clip from mouse, keyboard or controller; that the two engines are mutually exclusive; that the buttons re-enable after a clip finishes; and that the pressed animation no longer lingers when Space is held on a disabled button.

## Notes

- UI-only change contained to `haptics.cpp`; no public API changes.
